### PR TITLE
Shift test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Simple Cov #
+coverage/
+#tells git to ignore our simplecov tests, helps with memory usage and test runtime

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+​
+Rake::TestTask.new do |t|
+    t.pattern = "test/**/*_test.rb"
+end
+​
+task default: ["test"]

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,1 +1,10 @@
+class Enigma
 
+  def encrypt(message, key, date)
+
+  end
+
+  def decrypt(ciphertext, key, date)
+
+  end
+end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -34,11 +34,9 @@ class Shift
       date.to_i
     end
   end
-# a.map.with_index { |v, i| v + b[i] }
 
   def shift_key
     final_keys = {}
-    # require "pry"; binding.pry
     final_keys[:A] = offset_date_int[0] + key_grouping_int[0]
     final_keys[:B] = offset_date_int[1] + key_grouping_int[1]
     final_keys[:C] = offset_date_int[2] + key_grouping_int[2]

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,9 +1,20 @@
 class Shift
+  attr_reader :key, :date
 
-  def initialize(key = Array.new(5) {rand(0..9)},
-                date = Time.now.strftime("%d%m%y").to_i)
+  def initialize(key = (Array.new(5) {rand(0..9)}),
+                date = Time.now.strftime("%d%m%y"))
     @key = key
     @date = date
   end
+
+  def key_grouping
+    new_keys = []
+    key.split(//).each_cons(2) do |num|
+      new_keys << num.join
+    end
+    new_keys
+  end
+
+  
 
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -15,11 +15,31 @@ class Shift
     new_keys
   end
 
+  def key_grouping_int
+    key_grouping.map do |key|
+      key.to_i
+    end
+  end
+
   def squared_date
     (date.to_i ** 2).to_s
   end
 
   def offset_date
-    squared_date[-4..-1]
+    squared_date[-4..-1].split(//)
   end
+
+  def offset_date_int
+    offset_date.map do |date|
+      date.to_i
+    end
+  end
+
+
+  # def shift_key
+  #   final_keys = {}
+  #   require "pry"; binding.pry
+  # end
+
+
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -19,5 +19,7 @@ class Shift
     (date.to_i ** 2).to_s
   end
 
-
+  def offset_date
+    squared_date[-4..-1]
+  end
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -15,6 +15,9 @@ class Shift
     new_keys
   end
 
-  
+  def squared_date
+    (date.to_i ** 2).to_s
+  end
+
 
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,0 +1,9 @@
+class Shift
+
+  def initialize(key = Array.new(5) {rand(0..9)},
+                date = Time.now.strftime("%d%m%y").to_i)
+    @key = key
+    @date = date
+  end
+
+end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -34,12 +34,17 @@ class Shift
       date.to_i
     end
   end
+# a.map.with_index { |v, i| v + b[i] }
 
-
-  # def shift_key
-  #   final_keys = {}
-  #   require "pry"; binding.pry
-  # end
+  def shift_key
+    final_keys = {}
+    # require "pry"; binding.pry
+    final_keys[:A] = offset_date_int[0] + key_grouping_int[0]
+    final_keys[:B] = offset_date_int[1] + key_grouping_int[1]
+    final_keys[:C] = offset_date_int[2] + key_grouping_int[2]
+    final_keys[:D] = offset_date_int[3] + key_grouping_int[3]
+    final_keys
+  end
 
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,0 +1,39 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'date'
+require './lib/enigma'
+
+class EnigmaTest < Minitest::Test
+
+  def setup
+    @enigma = Enigma.new
+  end
+
+  def test_it_exists
+    assert_instance_of Enigma, @enigma
+  end
+
+  def test_can_encrypt_message_with_key_and_date
+    expected = {encryption: "keder ohulw", key: "02715", date: "040895"}
+    assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
+  end
+
+  def test_can_decrypt_message_with_key_and_date
+    expected = {decryption: "hello world", key: "02715", date: "040895"}
+    assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
+  end
+end
+
+
+
+# # encrypt a message with a key (uses today's date)
+# pry(main)> encrypted = enigma.encrypt("hello world", "02715")
+# #=> # encryption hash here
+#
+# #decrypt a message with a key (uses today's date)
+# pry(main) > enigma.decrypt(encrypted[:encryption], "02715")
+# #=> # decryption hash here
+#
+# # encrypt a message (generates random key and uses today's date)
+# pry(main)> enigma.encrypt("hello world")
+# #=> # encryption hash here

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -19,6 +19,16 @@ class ShiftTest < Minitest::Test
     assert_equal 6, @shift.date.length
   end
 
+  def test_keys_are_random
+    shift1 = Shift.new
+    shift2 = Shift.new
+    shift3 = Shift.new
+
+    assert_equal false, shift1 == shift2
+    assert_equal false, shift1 == shift3
+    assert_equal false, shift2 == shift3
+  end
+
   def test_keys_can_be_grouped
     @shift.stubs(:key => "01234")
     expected = ["01", "12", "23", "34"]

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -34,4 +34,19 @@ class ShiftTest < Minitest::Test
     expected = ["01", "12", "23", "34"]
     assert_equal expected, @shift.key_grouping
   end
+
+  def test_current_date_returned_as_default
+    shift1 = Shift.new
+    shift2 = Shift.new
+    shift3 = Shift.new
+
+    assert_equal true, shift1.date == shift2.date
+    assert_equal true, shift1.date == shift3.date
+    assert_equal true, shift2.date == shift3.date
+  end
+
+  def test_can_return_squared_date
+    @shift.stubs(:date => "010203")
+    assert_equal "104101209", @shift.squared_date
+  end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -35,6 +35,12 @@ class ShiftTest < Minitest::Test
     assert_equal expected, @shift.key_grouping
   end
 
+  def test_grouped_keys_can_be_returned_as_integers
+    @shift.stubs(:key => "01234")
+    expected = [1, 12, 23, 34]
+    assert_equal expected, @shift.key_grouping_int
+  end
+
   def test_current_date_returned_as_default
     shift1 = Shift.new
     shift2 = Shift.new
@@ -53,6 +59,27 @@ class ShiftTest < Minitest::Test
   def test_can_return_offset_date_value
     @shift.stubs(:date => "190287")
     assert_equal "36209142369", @shift.squared_date
-    assert_equal "2369", @shift.offset_date
+    assert_equal ["2", "3", "6", "9"], @shift.offset_date
+  end
+
+  def test_can_return_offset_date_value_as_integers
+    @shift.stubs(:date => "190287")
+    expected = [2, 3, 6, 9]
+    assert_equal expected, @shift.offset_date_int
+  end
+
+  def test_can_return_shift_key_values
+    skip
+    @shift.stubs(:key => "35468")
+    @shift.stubs(:date => "101112")
+    assert_equal ["41", "59", "50", "72"], @shift.shift_values
+  end
+
+  def test_can_create_key_and_offset_date_hash
+    skip
+    @shift.stubs(:key => "35468")
+    @shift.stubs(:date => "101112")
+    expected = {A: 41, B: 59, C: 50, D: 72}
+    assert_equal expected, @shift.shift_key
   end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -5,11 +5,23 @@ require './lib/shift'
 class ShiftTest < Minitest::Test
 
   def setup
-    @shift = Shift.new("02715", "040895")
+    @shift = Shift.new
   end
 
   def test_it_exists
     assert_instance_of Shift, @shift
   end
 
+  def test_it_has_attributes
+    assert_equal Array, @shift.key.class
+    assert_equal 5, @shift.key.length
+    assert_equal String, @shift.date.class
+    assert_equal 6, @shift.date.length
+  end
+
+  def test_keys_can_be_grouped
+    @shift.stubs(:key => "01234")
+    expected = ["01", "12", "23", "34"]
+    assert_equal expected, @shift.key_grouping
+  end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -68,17 +68,11 @@ class ShiftTest < Minitest::Test
     assert_equal expected, @shift.offset_date_int
   end
 
-  def test_can_return_shift_key_values
-    skip
-    @shift.stubs(:key => "35468")
-    @shift.stubs(:date => "101112")
-    assert_equal ["41", "59", "50", "72"], @shift.shift_values
-  end
-
   def test_can_create_key_and_offset_date_hash
-    skip
     @shift.stubs(:key => "35468")
     @shift.stubs(:date => "101112")
+    # @shift.offset_date_int
+    # @shift.key_grouping_int
     expected = {A: 41, B: 59, C: 50, D: 72}
     assert_equal expected, @shift.shift_key
   end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -49,4 +49,10 @@ class ShiftTest < Minitest::Test
     @shift.stubs(:date => "010203")
     assert_equal "104101209", @shift.squared_date
   end
+
+  def test_can_return_offset_date_value
+    @shift.stubs(:date => "190287")
+    assert_equal "36209142369", @shift.squared_date
+    assert_equal "2369", @shift.offset_date
+  end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -1,0 +1,15 @@
+require_relative 'test_helper'
+require 'date'
+require './lib/shift'
+
+class ShiftTest < Minitest::Test
+
+  def setup
+    @shift = Shift.new("02715", "040895")
+  end
+
+  def test_it_exists
+    assert_instance_of Shift, @shift
+  end
+
+end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -59,7 +59,8 @@ class ShiftTest < Minitest::Test
   def test_can_return_offset_date_value
     @shift.stubs(:date => "190287")
     assert_equal "36209142369", @shift.squared_date
-    assert_equal ["2", "3", "6", "9"], @shift.offset_date
+    expected = ["2", "3", "6", "9"]
+    assert_equal expected, @shift.offset_date
   end
 
   def test_can_return_offset_date_value_as_integers
@@ -71,8 +72,6 @@ class ShiftTest < Minitest::Test
   def test_can_create_key_and_offset_date_hash
     @shift.stubs(:key => "35468")
     @shift.stubs(:date => "101112")
-    # @shift.offset_date_int
-    # @shift.key_grouping_int
     expected = {A: 41, B: 59, C: 50, D: 72}
     assert_equal expected, @shift.shift_key
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,5 @@
+require 'simplecov'
+SimpleCov.start
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/minitest'


### PR DESCRIPTION
Shift class and test created to calculate shift key values to be used for encryption and decryption. Used stubs to test key and date values. Class is initialized with key variable as random array of 5  and date variable with a default of current date. Methods work similarly as they both are manipulated and are able to be returned as strings and integers. The shift key method combines both the key and date variables into a new hash to be used for Enigma class.